### PR TITLE
Add parent type

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,7 @@ types = {
         functions = { -- Optional
             -- See function structure below
         },
+        parenttype = 'Parenttype' --Optional
         supertypes = { -- Optional
             'Supertype'
         },

--- a/love_api.lua
+++ b/love_api.lua
@@ -104,6 +104,7 @@ return {
                     }
                 }
             },
+            parenttype = 'Object',
             supertypes = {
                 'Object'
             },
@@ -120,6 +121,7 @@ return {
         {
             name = 'Drawable',
             description = 'Superclass for all things that can be drawn on screen. This is an abstract type that can\'t be created directly.',
+            parenttype = 'Object',
             supertypes = {
                 'Object'
             },

--- a/modules/audio/types/Source.lua
+++ b/modules/audio/types/Source.lua
@@ -607,6 +607,7 @@ return {
             }
         }
     },
+    parenttype = 'Object',
     supertypes = {
         'Object'
     }

--- a/modules/filesystem/types/File.lua
+++ b/modules/filesystem/types/File.lua
@@ -283,6 +283,7 @@ return {
             }
         }
     },
+    parenttype = 'Object',
     supertypes = {
         'Object'
     }

--- a/modules/filesystem/types/FileData.lua
+++ b/modules/filesystem/types/FileData.lua
@@ -36,6 +36,7 @@ return {
             }
         }
     },
+    parenttype = 'Data',
     supertypes = {
         'Data',
         'Object'

--- a/modules/graphics/types/Canvas.lua
+++ b/modules/graphics/types/Canvas.lua
@@ -240,6 +240,7 @@ return {
             }
         }
     },
+    parenttype = 'Texture',
     supertypes = {
         'Object',
         'Drawable',

--- a/modules/graphics/types/Font.lua
+++ b/modules/graphics/types/Font.lua
@@ -262,6 +262,7 @@ return {
             }
         }
     },
+    parenttype = 'Object',
     supertypes = {
         'Object'
     }

--- a/modules/graphics/types/Image.lua
+++ b/modules/graphics/types/Image.lua
@@ -252,6 +252,7 @@ return {
             }
         }
     },
+    parenttype = 'Texture',
     supertypes = {
         'Object',
         'Drawable',

--- a/modules/graphics/types/Mesh.lua
+++ b/modules/graphics/types/Mesh.lua
@@ -683,6 +683,7 @@ return {
             }
         }
     },
+    parenttype = 'Drawable',
     supertypes = {
         'Drawable',
         'Object'

--- a/modules/graphics/types/ParticleSystem.lua
+++ b/modules/graphics/types/ParticleSystem.lua
@@ -1124,6 +1124,7 @@ return {
             }
         }
     },
+    parenttype = 'Drawable',
     supertypes = {
         'Drawable',
         'Object'

--- a/modules/graphics/types/Quad.lua
+++ b/modules/graphics/types/Quad.lua
@@ -86,6 +86,7 @@ return {
             }
         }
     },
+    parenttype = 'Object',
     supertypes = {
         'Object'
     }

--- a/modules/graphics/types/Shader.lua
+++ b/modules/graphics/types/Shader.lua
@@ -174,6 +174,7 @@ return {
             }
         }
     },
+    parenttype = 'Object',
     supertypes = {
         'Object'
     }

--- a/modules/graphics/types/SpriteBatch.lua
+++ b/modules/graphics/types/SpriteBatch.lua
@@ -449,6 +449,7 @@ return {
             }
         }
     },
+    parenttype = 'Drawable',
     supertypes = {
         'Drawable',
         'Object'

--- a/modules/graphics/types/Text.lua
+++ b/modules/graphics/types/Text.lua
@@ -637,6 +637,7 @@ return {
             }
         }
     },
+    parenttype = 'Drawable',
     supertypes = {
         'Drawable',
         'Object'

--- a/modules/graphics/types/Texture.lua
+++ b/modules/graphics/types/Texture.lua
@@ -3,6 +3,7 @@ return {
     description = 'Superclass for drawable objects which represent a texture. All Textures can be drawn with Quads. This is an abstract type that can\'t be created directly.',
     constructors = {},
     functions = {},
+    parenttype = 'Drawable',
     supertypes = {
         'Drawable',
         'Object'

--- a/modules/graphics/types/Video.lua
+++ b/modules/graphics/types/Video.lua
@@ -220,6 +220,7 @@ return {
             }
         }
     },
+    parenttype = 'Drawable',
     supertypes = {
         'Drawable',
         'Object'

--- a/modules/image/types/CompressedImageData.lua
+++ b/modules/image/types/CompressedImageData.lua
@@ -139,6 +139,7 @@ return {
             }
         }
     },
+    parenttype = 'Data',
     supertypes = {
         'Data',
         'Object'

--- a/modules/image/types/ImageData.lua
+++ b/modules/image/types/ImageData.lua
@@ -226,6 +226,7 @@ return {
             }
         }
     },
+    parenttype = 'Data',
     supertypes = {
         'Data',
         'Object'

--- a/modules/joystick/types/Joystick.lua
+++ b/modules/joystick/types/Joystick.lua
@@ -421,6 +421,7 @@ return {
             }
         }
     },
+    parenttype = 'Object',
     supertypes = {
         'Object'
     }

--- a/modules/math/types/BezierCurve.lua
+++ b/modules/math/types/BezierCurve.lua
@@ -328,6 +328,7 @@ return {
             }
         }
     },
+    parenttype = 'Object',
     supertypes = {
         'Object'
     }

--- a/modules/math/types/CompressedData.lua
+++ b/modules/math/types/CompressedData.lua
@@ -21,6 +21,7 @@ return {
             }
         }
     },
+    parenttype = 'Data',
     supertypes = {
         'Data',
         'Object'

--- a/modules/math/types/RandomGenerator.lua
+++ b/modules/math/types/RandomGenerator.lua
@@ -170,6 +170,7 @@ return {
             }
         }
     },
+    parenttype = 'Object',
     supertypes = {
         'Object'
     }

--- a/modules/mouse/types/Cursor.lua
+++ b/modules/mouse/types/Cursor.lua
@@ -22,6 +22,7 @@ return {
             }
         }
     },
+    parenttype = 'Object',
     supertypes = {
         'Object'
     }

--- a/modules/physics/types/Body.lua
+++ b/modules/physics/types/Body.lua
@@ -1127,6 +1127,7 @@ return {
             }
         }
     },
+    parenttype = 'Object',
     supertypes = {
         'Object'
     }

--- a/modules/physics/types/ChainShape.lua
+++ b/modules/physics/types/ChainShape.lua
@@ -189,6 +189,7 @@ return {
             }
         }
     },
+    parenttype = 'Shape',
     supertypes = {
         'Shape',
         'Object'

--- a/modules/physics/types/CircleShape.lua
+++ b/modules/physics/types/CircleShape.lua
@@ -76,6 +76,7 @@ return {
             }
         }
     },
+    parenttype = 'Shape',
     supertypes = {
         'Shape',
         'Object'

--- a/modules/physics/types/Contact.lua
+++ b/modules/physics/types/Contact.lua
@@ -192,6 +192,7 @@ return {
             }
         }
     },
+    parenttype = 'Object',
     supertypes = {
         'Object'
     }

--- a/modules/physics/types/DistanceJoint.lua
+++ b/modules/physics/types/DistanceJoint.lua
@@ -96,6 +96,7 @@ return {
             }
         }
     },
+    parenttype = 'Joint',
     supertypes = {
         'Object',
         'Joint'

--- a/modules/physics/types/EdgeShape.lua
+++ b/modules/physics/types/EdgeShape.lua
@@ -116,6 +116,7 @@ return {
             }
         }
     },
+    parenttype = 'Shape',
     supertypes = {
         'Shape',
         'Object'

--- a/modules/physics/types/Fixture.lua
+++ b/modules/physics/types/Fixture.lua
@@ -541,6 +541,7 @@ return {
             }
         }
     },
+    parenttype = 'Object',
     supertypes = {
         'Object'
     }

--- a/modules/physics/types/FrictionJoint.lua
+++ b/modules/physics/types/FrictionJoint.lua
@@ -66,6 +66,7 @@ return {
             }
         }
     },
+    parenttype = 'Joint',
     supertypes = {
         'Object',
         'Joint'

--- a/modules/physics/types/GearJoint.lua
+++ b/modules/physics/types/GearJoint.lua
@@ -56,6 +56,7 @@ return {
             }
         }
     },
+    parenttype = 'Joint',
     supertypes = {
         'Object',
         'Joint'

--- a/modules/physics/types/Joint.lua
+++ b/modules/physics/types/Joint.lua
@@ -177,6 +177,7 @@ return {
             }
         }
     },
+    parenttype = 'Object',
     supertypes = {
         'Object'
     },

--- a/modules/physics/types/MotorJoint.lua
+++ b/modules/physics/types/MotorJoint.lua
@@ -76,6 +76,7 @@ return {
             }
         }
     },
+    parenttype = 'Joint',
     supertypes = {
         'Object',
         'Joint'

--- a/modules/physics/types/MouseJoint.lua
+++ b/modules/physics/types/MouseJoint.lua
@@ -136,6 +136,7 @@ return {
             }
         }
     },
+    parenttype = 'Joint',
     supertypes = {
         'Object',
         'Joint'

--- a/modules/physics/types/PolygonShape.lua
+++ b/modules/physics/types/PolygonShape.lua
@@ -42,6 +42,7 @@ return {
             }
         }
     },
+    parenttype = 'Shape',
     supertypes = {
         'Shape',
         'Object'

--- a/modules/physics/types/PrismaticJoint.lua
+++ b/modules/physics/types/PrismaticJoint.lua
@@ -291,6 +291,7 @@ return {
             }
         }
     },
+    parenttype = 'Joint',
     supertypes = {
         'Object',
         'Joint'

--- a/modules/physics/types/PulleyJoint.lua
+++ b/modules/physics/types/PulleyJoint.lua
@@ -166,6 +166,7 @@ return {
             }
         }
     },
+    parenttype = 'Joint',
     supertypes = {
         'Object',
         'Joint'

--- a/modules/physics/types/RevoluteJoint.lua
+++ b/modules/physics/types/RevoluteJoint.lua
@@ -271,6 +271,7 @@ return {
             }
         }
     },
+    parenttype = 'Joint',
     supertypes = {
         'Object',
         'Joint'

--- a/modules/physics/types/RopeJoint.lua
+++ b/modules/physics/types/RopeJoint.lua
@@ -21,6 +21,7 @@ return {
             }
         }
     },
+    parenttype = 'Joint',
     supertypes = {
         'Object',
         'Joint'

--- a/modules/physics/types/Shape.lua
+++ b/modules/physics/types/Shape.lua
@@ -244,6 +244,7 @@ return {
             }
         }
     },
+    parenttype = 'Object',
     supertypes = {
         'Object'
     },

--- a/modules/physics/types/WeldJoint.lua
+++ b/modules/physics/types/WeldJoint.lua
@@ -66,6 +66,7 @@ return {
             }
         }
     },
+    parenttype = 'Joint',
     supertypes = {
         'Object',
         'Joint'

--- a/modules/physics/types/WheelJoint.lua
+++ b/modules/physics/types/WheelJoint.lua
@@ -233,6 +233,7 @@ return {
             }
         },
     },
+    parenttype = 'Joint',
     supertypes = {
         'Object',
         'Joint'

--- a/modules/physics/types/World.lua
+++ b/modules/physics/types/World.lua
@@ -398,6 +398,7 @@ return {
             }
         }
     },
+    parenttype = 'Object',
     supertypes = {
         'Object'
     }

--- a/modules/sound/types/Decoder.lua
+++ b/modules/sound/types/Decoder.lua
@@ -66,6 +66,7 @@ return {
             }
         }
     },
+    parenttype = 'Object',
     supertypes = {
         'Object'
     }

--- a/modules/sound/types/SoundData.lua
+++ b/modules/sound/types/SoundData.lua
@@ -123,6 +123,7 @@ return {
             }
         }
     },
+    parenttype = 'Data',
     supertypes = {
         'Data',
         'Object'

--- a/modules/thread/types/Channel.lua
+++ b/modules/thread/types/Channel.lua
@@ -141,6 +141,7 @@ return {
             }
         },
     },
+    parenttype = 'Object',
     supertypes = {
         'Object'
     }

--- a/modules/thread/types/Thread.lua
+++ b/modules/thread/types/Thread.lua
@@ -69,6 +69,7 @@ return {
             }
         }
     },
+    parenttype = 'Object',
     supertypes = {
         'Object'
     }

--- a/modules/video/types/VideoStream.lua
+++ b/modules/video/types/VideoStream.lua
@@ -5,6 +5,7 @@ return {
         'newVideoStream'
     },
     functions = {},
+    parenttype = 'Object',
     supertypes = {
         'Object'
     }

--- a/specs/api_spec.lua
+++ b/specs/api_spec.lua
@@ -38,6 +38,7 @@ describe( 'LÖVE-API Integrity test', function()
             'name',
             'notes',
             'returns',
+            'parenttype',
             'supertypes',
             'subtypes',
             'table',


### PR DESCRIPTION
Parenttype is the direct parent Supertype which the Type inherits from.

This is useful to know which Type inherits from whom exactly so you can do stuff like:
```lua
setmetatable(Canvas,   {__index = Texture }) --Canvas   Parenttype is Texture
setmetatable(Texture,  {__index = Drawable}) --Texture  Parenttype is Drawable
setmetatable(Drawable, {__index = Object  }) --Drawable Parenttype is Object
```
So then `Canvas` has all the methods from `Texture`, `Drawable` and `Object` all it's Supertypes.