### PR TITLE
Using string buffer for faster string concatenation

### DIFF
--- a/generator/html-generator.lua
+++ b/generator/html-generator.lua
@@ -286,7 +286,7 @@ order = {
     },
 }
 
-output = ''
+output = {}
 
 function make_function_navigation_link(m, f_, prefix)
     local getterprefixes = {'get', 'is', 'has', 'are', 'to', 'load', 'tell'}
@@ -880,7 +880,7 @@ function tr(s)
 end
 
 function append(s)
-    output = output .. s .. '\n'
+    table.insert(output, s)
 end
 
 main()
@@ -892,4 +892,4 @@ function string_to_file(s, f)
 end
 
 
-string_to_file(output:gsub('�', '&Ouml;'):gsub('Ö', '&Ouml;'):gsub('é', '&eacute;'), 'index.html')
+string_to_file(table.concat(output, ''):gsub('�', '&Ouml;'):gsub('Ö', '&Ouml;'):gsub('é', '&eacute;'), 'index.html')


### PR DESCRIPTION
This increases the performance of the script. For more information see https://www.lua.org/pil/11.6.html. 
Would love to see string buffers in the whole script for faster development and testing. :+1: 

Before:
```
time ./update.sh 

real	0m8,036s
user	0m7,084s
sys	0m0,950s
```

After:
```
time ./update.sh 

real	0m4,633s
user	0m4,596s
sys	0m0,038s
```