### PR TITLE
Added CSS files for backward compatibility

### DIFF
--- a/0.10.0/index.html
+++ b/0.10.0/index.html
@@ -1,6 +1,6 @@
 <html>
     <head>
-    <link rel="stylesheet" type="text/css" href="../pure-love.css">
+    <link rel="stylesheet" type="text/css" href="./pure-love.css">
     <title>L&Ouml;VE 0.10.0 Reference</title>
     </head>
     <body>

--- a/0.10.0/pure-love.css
+++ b/0.10.0/pure-love.css
@@ -1,0 +1,161 @@
+* {
+    margin: 0;
+    padding: 0;
+    color: #333;
+}
+
+p, td, h1, h2, h3 {
+    font-family: "Trebuchet MS", sans-serif;
+}
+
+a:link {
+    text-decoration: none;
+}
+
+.synopsis, .return_name, .return_type, .argument_name, .argument_type, .constant_name {
+    font-family: "Consolas", monospace;
+}
+
+.navigation {
+    position: fixed;
+    margin-left: 2px;
+    margin-top: 12px;
+}
+
+.container {
+    margin-left: 105px;
+}
+
+p, td {
+    font-size: 10pt;
+}
+.modules, .callbacks, .navigation_link {
+    font-size: 10pt;
+}
+.module_name, .callbacks_title, .name, .type_name, .enum_name {
+    font-size: 16pt;
+    margin-bottom: 8px;
+}
+.synopsis {
+    font-size: 12pt;
+}
+
+.argument_name, .return_name {
+    text-align: right;
+}
+
+.argument_type, .return_type {
+    padding-left: 16px;
+}
+
+body {
+    margin-left: 12px;
+    margin-bottom: 24px;
+}
+
+.function, .function_link, .type_link, .enum_link, .subsection {
+    margin-left: 24px;
+}
+
+.description {
+    margin-left: 12px;
+}
+
+.callbacks_title, .module_navigation, .subsection {
+    margin-top: 8px;
+}
+.module_name, .synopsis {
+    margin-top: 16px;
+}
+.synopsis {
+    margin-bottom: 12px;
+}
+
+.constant_description {
+    margin-bottom: 8px;
+}
+
+.returns_table, .arguments_table, .flags_table {
+    margin-bottom: 8px;
+}
+
+table {
+    vertical-align: text-top;
+}
+td {
+    vertical-align: top;
+}
+.name, .arguments, .returns, .argument, .return, .argument_name, .return_name, .argument_type, .argument_type a, .return_type, .return_type a, .constant_name, .type_name, .enum_name, .module_navigation, .module_name, .callbacks_title, .subsection {
+    font-weight: bold;
+}
+
+.name, .type_name, .enum_name, .module_name {
+    margin-top: 12px;
+}
+
+
+.arguments, .returns {
+    text-transform: uppercase;
+}
+
+.module_name a, .type_name a, .enum_name a, .callbacks_title a, .module_navigation, .default, .subsection {
+    color: #777474;
+}
+
+a {
+    color: #2680C6; /* Blue */
+}
+.name a, .argument_name, .argument, .constant_name, .green {
+    color: #7CAF45; /* Green */
+}
+.return_name, .return {
+    color: #CC6600; /* Orange */
+    color: #D86C00; /* Orange */
+}
+.argument_name, .argument {
+    color: #E658A0; /* Pink */
+}
+
+.argument_name, .return_name {
+    width: 120px;
+}
+
+.argument_type, .return_type {
+    width: 100px;
+}
+
+.callbacks_title {
+    margin-top: 0;
+}
+
+.navigation_link a:hover, .function_link a:hover, .type_link a:hover, .enum_link a:hover, .return_type a:hover, .argument_type a:hover  {
+    background-color: #ECF3F7;
+}
+
+.background {
+    margin-left: -12px;
+    line-height: 150%;
+    background-color: #F5F5F5;
+    border-color: #D7D4D4;
+    background-color: #F7F4F4;
+    border-width: 1px;
+    border-style: solid;
+    padding: 2px 5px 2px 5px;
+    margin-left: -5px;
+}
+
+.function_section, .navigation_section, .module_section, .enum_section, .navigation_links_section {
+    margin-bottom: 40px;
+}
+
+.navigation_links_section {
+    margin-top: 20px;
+}
+
+.module_name, .callbacks_title {
+    font-size: 28px;
+}
+
+.light, .arguments, .returns, .subsection {
+    color: #A7A4A4;
+}

--- a/0.10.1/index.html
+++ b/0.10.1/index.html
@@ -1,6 +1,6 @@
 <html>
     <head>
-    <link rel="stylesheet" type="text/css" href="../pure-love.css">
+    <link rel="stylesheet" type="text/css" href="./pure-love.css">
     <title>L&Ouml;VE 0.10.1 Reference</title>
     </head>
     <body>

--- a/0.10.1/pure-love.css
+++ b/0.10.1/pure-love.css
@@ -1,0 +1,161 @@
+* {
+    margin: 0;
+    padding: 0;
+    color: #333;
+}
+
+p, td, h1, h2, h3 {
+    font-family: "Trebuchet MS", sans-serif;
+}
+
+a:link {
+    text-decoration: none;
+}
+
+.synopsis, .return_name, .return_type, .argument_name, .argument_type, .constant_name {
+    font-family: "Consolas", monospace;
+}
+
+.navigation {
+    position: fixed;
+    margin-left: 2px;
+    margin-top: 12px;
+}
+
+.container {
+    margin-left: 105px;
+}
+
+p, td {
+    font-size: 10pt;
+}
+.modules, .callbacks, .navigation_link {
+    font-size: 10pt;
+}
+.module_name, .callbacks_title, .name, .type_name, .enum_name {
+    font-size: 16pt;
+    margin-bottom: 8px;
+}
+.synopsis {
+    font-size: 12pt;
+}
+
+.argument_name, .return_name {
+    text-align: right;
+}
+
+.argument_type, .return_type {
+    padding-left: 16px;
+}
+
+body {
+    margin-left: 12px;
+    margin-bottom: 24px;
+}
+
+.function, .function_link, .type_link, .enum_link, .subsection {
+    margin-left: 24px;
+}
+
+.description {
+    margin-left: 12px;
+}
+
+.callbacks_title, .module_navigation, .subsection {
+    margin-top: 8px;
+}
+.module_name, .synopsis {
+    margin-top: 16px;
+}
+.synopsis {
+    margin-bottom: 12px;
+}
+
+.constant_description {
+    margin-bottom: 8px;
+}
+
+.returns_table, .arguments_table, .flags_table {
+    margin-bottom: 8px;
+}
+
+table {
+    vertical-align: text-top;
+}
+td {
+    vertical-align: top;
+}
+.name, .arguments, .returns, .argument, .return, .argument_name, .return_name, .argument_type, .argument_type a, .return_type, .return_type a, .constant_name, .type_name, .enum_name, .module_navigation, .module_name, .callbacks_title, .subsection {
+    font-weight: bold;
+}
+
+.name, .type_name, .enum_name, .module_name {
+    margin-top: 12px;
+}
+
+
+.arguments, .returns {
+    text-transform: uppercase;
+}
+
+.module_name a, .type_name a, .enum_name a, .callbacks_title a, .module_navigation, .default, .subsection {
+    color: #777474;
+}
+
+a {
+    color: #2680C6; /* Blue */
+}
+.name a, .argument_name, .argument, .constant_name, .green {
+    color: #7CAF45; /* Green */
+}
+.return_name, .return {
+    color: #CC6600; /* Orange */
+    color: #D86C00; /* Orange */
+}
+.argument_name, .argument {
+    color: #E658A0; /* Pink */
+}
+
+.argument_name, .return_name {
+    width: 120px;
+}
+
+.argument_type, .return_type {
+    width: 100px;
+}
+
+.callbacks_title {
+    margin-top: 0;
+}
+
+.navigation_link a:hover, .function_link a:hover, .type_link a:hover, .enum_link a:hover, .return_type a:hover, .argument_type a:hover  {
+    background-color: #ECF3F7;
+}
+
+.background {
+    margin-left: -12px;
+    line-height: 150%;
+    background-color: #F5F5F5;
+    border-color: #D7D4D4;
+    background-color: #F7F4F4;
+    border-width: 1px;
+    border-style: solid;
+    padding: 2px 5px 2px 5px;
+    margin-left: -5px;
+}
+
+.function_section, .navigation_section, .module_section, .enum_section, .navigation_links_section {
+    margin-bottom: 40px;
+}
+
+.navigation_links_section {
+    margin-top: 20px;
+}
+
+.module_name, .callbacks_title {
+    font-size: 28px;
+}
+
+.light, .arguments, .returns, .subsection {
+    color: #A7A4A4;
+}

--- a/0.10.2/index.html
+++ b/0.10.2/index.html
@@ -1,6 +1,6 @@
 <html>
     <head>
-    <link rel="stylesheet" type="text/css" href="../pure-love.css">
+    <link rel="stylesheet" type="text/css" href="./pure-love.css">
     <title>L&Ouml;VE 0.10.2 Reference</title>
     </head>
     <body>

--- a/0.10.2/pure-love.css
+++ b/0.10.2/pure-love.css
@@ -1,0 +1,161 @@
+* {
+    margin: 0;
+    padding: 0;
+    color: #333;
+}
+
+p, td, h1, h2, h3 {
+    font-family: "Trebuchet MS", sans-serif;
+}
+
+a:link {
+    text-decoration: none;
+}
+
+.synopsis, .return_name, .return_type, .argument_name, .argument_type, .constant_name {
+    font-family: "Consolas", monospace;
+}
+
+.navigation {
+    position: fixed;
+    margin-left: 2px;
+    margin-top: 12px;
+}
+
+.container {
+    margin-left: 105px;
+}
+
+p, td {
+    font-size: 10pt;
+}
+.modules, .callbacks, .navigation_link {
+    font-size: 10pt;
+}
+.module_name, .callbacks_title, .name, .type_name, .enum_name {
+    font-size: 16pt;
+    margin-bottom: 8px;
+}
+.synopsis {
+    font-size: 12pt;
+}
+
+.argument_name, .return_name {
+    text-align: right;
+}
+
+.argument_type, .return_type {
+    padding-left: 16px;
+}
+
+body {
+    margin-left: 12px;
+    margin-bottom: 24px;
+}
+
+.function, .function_link, .type_link, .enum_link, .subsection {
+    margin-left: 24px;
+}
+
+.description {
+    margin-left: 12px;
+}
+
+.callbacks_title, .module_navigation, .subsection {
+    margin-top: 8px;
+}
+.module_name, .synopsis {
+    margin-top: 16px;
+}
+.synopsis {
+    margin-bottom: 12px;
+}
+
+.constant_description {
+    margin-bottom: 8px;
+}
+
+.returns_table, .arguments_table, .flags_table {
+    margin-bottom: 8px;
+}
+
+table {
+    vertical-align: text-top;
+}
+td {
+    vertical-align: top;
+}
+.name, .arguments, .returns, .argument, .return, .argument_name, .return_name, .argument_type, .argument_type a, .return_type, .return_type a, .constant_name, .type_name, .enum_name, .module_navigation, .module_name, .callbacks_title, .subsection {
+    font-weight: bold;
+}
+
+.name, .type_name, .enum_name, .module_name {
+    margin-top: 12px;
+}
+
+
+.arguments, .returns {
+    text-transform: uppercase;
+}
+
+.module_name a, .type_name a, .enum_name a, .callbacks_title a, .module_navigation, .default, .subsection {
+    color: #777474;
+}
+
+a {
+    color: #2680C6; /* Blue */
+}
+.name a, .argument_name, .argument, .constant_name, .green {
+    color: #7CAF45; /* Green */
+}
+.return_name, .return {
+    color: #CC6600; /* Orange */
+    color: #D86C00; /* Orange */
+}
+.argument_name, .argument {
+    color: #E658A0; /* Pink */
+}
+
+.argument_name, .return_name {
+    width: 120px;
+}
+
+.argument_type, .return_type {
+    width: 100px;
+}
+
+.callbacks_title {
+    margin-top: 0;
+}
+
+.navigation_link a:hover, .function_link a:hover, .type_link a:hover, .enum_link a:hover, .return_type a:hover, .argument_type a:hover  {
+    background-color: #ECF3F7;
+}
+
+.background {
+    margin-left: -12px;
+    line-height: 150%;
+    background-color: #F5F5F5;
+    border-color: #D7D4D4;
+    background-color: #F7F4F4;
+    border-width: 1px;
+    border-style: solid;
+    padding: 2px 5px 2px 5px;
+    margin-left: -5px;
+}
+
+.function_section, .navigation_section, .module_section, .enum_section, .navigation_links_section {
+    margin-bottom: 40px;
+}
+
+.navigation_links_section {
+    margin-top: 20px;
+}
+
+.module_name, .callbacks_title {
+    font-size: 28px;
+}
+
+.light, .arguments, .returns, .subsection {
+    color: #A7A4A4;
+}

--- a/0.9.1/index.html
+++ b/0.9.1/index.html
@@ -1,6 +1,6 @@
 <html>
     <head>
-    <link rel="stylesheet" type="text/css" href="../pure-love.css">
+    <link rel="stylesheet" type="text/css" href="./pure-love.css">
     <title>L&Ouml;VE 0.9.1 Reference</title>
     </head>
     <body>

--- a/0.9.1/pure-love.css
+++ b/0.9.1/pure-love.css
@@ -1,0 +1,161 @@
+* {
+    margin: 0;
+    padding: 0;
+    color: #333;
+}
+
+p, td, h1, h2, h3 {
+    font-family: "Trebuchet MS", sans-serif;
+}
+
+a:link {
+    text-decoration: none;
+}
+
+.synopsis, .return_name, .return_type, .argument_name, .argument_type, .constant_name {
+    font-family: "Consolas", monospace;
+}
+
+.navigation {
+    position: fixed;
+    margin-left: 2px;
+    margin-top: 12px;
+}
+
+.container {
+    margin-left: 105px;
+}
+
+p, td {
+    font-size: 10pt;
+}
+.modules, .callbacks, .navigation_link {
+    font-size: 10pt;
+}
+.module_name, .callbacks_title, .name, .type_name, .enum_name {
+    font-size: 16pt;
+    margin-bottom: 8px;
+}
+.synopsis {
+    font-size: 12pt;
+}
+
+.argument_name, .return_name {
+    text-align: right;
+}
+
+.argument_type, .return_type {
+    padding-left: 16px;
+}
+
+body {
+    margin-left: 12px;
+    margin-bottom: 24px;
+}
+
+.function, .function_link, .type_link, .enum_link, .subsection {
+    margin-left: 24px;
+}
+
+.description {
+    margin-left: 12px;
+}
+
+.callbacks_title, .module_navigation, .subsection {
+    margin-top: 8px;
+}
+.module_name, .synopsis {
+    margin-top: 16px;
+}
+.synopsis {
+    margin-bottom: 12px;
+}
+
+.constant_description {
+    margin-bottom: 8px;
+}
+
+.returns_table, .arguments_table, .flags_table {
+    margin-bottom: 8px;
+}
+
+table {
+    vertical-align: text-top;
+}
+td {
+    vertical-align: top;
+}
+.name, .arguments, .returns, .argument, .return, .argument_name, .return_name, .argument_type, .argument_type a, .return_type, .return_type a, .constant_name, .type_name, .enum_name, .module_navigation, .module_name, .callbacks_title, .subsection {
+    font-weight: bold;
+}
+
+.name, .type_name, .enum_name, .module_name {
+    margin-top: 12px;
+}
+
+
+.arguments, .returns {
+    text-transform: uppercase;
+}
+
+.module_name a, .type_name a, .enum_name a, .callbacks_title a, .module_navigation, .default, .subsection {
+    color: #777474;
+}
+
+a {
+    color: #2680C6; /* Blue */
+}
+.name a, .argument_name, .argument, .constant_name, .green {
+    color: #7CAF45; /* Green */
+}
+.return_name, .return {
+    color: #CC6600; /* Orange */
+    color: #D86C00; /* Orange */
+}
+.argument_name, .argument {
+    color: #E658A0; /* Pink */
+}
+
+.argument_name, .return_name {
+    width: 120px;
+}
+
+.argument_type, .return_type {
+    width: 100px;
+}
+
+.callbacks_title {
+    margin-top: 0;
+}
+
+.navigation_link a:hover, .function_link a:hover, .type_link a:hover, .enum_link a:hover, .return_type a:hover, .argument_type a:hover  {
+    background-color: #ECF3F7;
+}
+
+.background {
+    margin-left: -12px;
+    line-height: 150%;
+    background-color: #F5F5F5;
+    border-color: #D7D4D4;
+    background-color: #F7F4F4;
+    border-width: 1px;
+    border-style: solid;
+    padding: 2px 5px 2px 5px;
+    margin-left: -5px;
+}
+
+.function_section, .navigation_section, .module_section, .enum_section, .navigation_links_section {
+    margin-bottom: 40px;
+}
+
+.navigation_links_section {
+    margin-top: 20px;
+}
+
+.module_name, .callbacks_title {
+    font-size: 28px;
+}
+
+.light, .arguments, .returns, .subsection {
+    color: #A7A4A4;
+}

--- a/0.9.2/index.html
+++ b/0.9.2/index.html
@@ -1,6 +1,6 @@
 <html>
     <head>
-    <link rel="stylesheet" type="text/css" href="../pure-love.css">
+    <link rel="stylesheet" type="text/css" href="./pure-love.css">
     <title>L&Ouml;VE 0.9.2 Reference</title>
     </head>
     <body>

--- a/0.9.2/pure-love.css
+++ b/0.9.2/pure-love.css
@@ -1,0 +1,161 @@
+* {
+    margin: 0;
+    padding: 0;
+    color: #333;
+}
+
+p, td, h1, h2, h3 {
+    font-family: "Trebuchet MS", sans-serif;
+}
+
+a:link {
+    text-decoration: none;
+}
+
+.synopsis, .return_name, .return_type, .argument_name, .argument_type, .constant_name {
+    font-family: "Consolas", monospace;
+}
+
+.navigation {
+    position: fixed;
+    margin-left: 2px;
+    margin-top: 12px;
+}
+
+.container {
+    margin-left: 105px;
+}
+
+p, td {
+    font-size: 10pt;
+}
+.modules, .callbacks, .navigation_link {
+    font-size: 10pt;
+}
+.module_name, .callbacks_title, .name, .type_name, .enum_name {
+    font-size: 16pt;
+    margin-bottom: 8px;
+}
+.synopsis {
+    font-size: 12pt;
+}
+
+.argument_name, .return_name {
+    text-align: right;
+}
+
+.argument_type, .return_type {
+    padding-left: 16px;
+}
+
+body {
+    margin-left: 12px;
+    margin-bottom: 24px;
+}
+
+.function, .function_link, .type_link, .enum_link, .subsection {
+    margin-left: 24px;
+}
+
+.description {
+    margin-left: 12px;
+}
+
+.callbacks_title, .module_navigation, .subsection {
+    margin-top: 8px;
+}
+.module_name, .synopsis {
+    margin-top: 16px;
+}
+.synopsis {
+    margin-bottom: 12px;
+}
+
+.constant_description {
+    margin-bottom: 8px;
+}
+
+.returns_table, .arguments_table, .flags_table {
+    margin-bottom: 8px;
+}
+
+table {
+    vertical-align: text-top;
+}
+td {
+    vertical-align: top;
+}
+.name, .arguments, .returns, .argument, .return, .argument_name, .return_name, .argument_type, .argument_type a, .return_type, .return_type a, .constant_name, .type_name, .enum_name, .module_navigation, .module_name, .callbacks_title, .subsection {
+    font-weight: bold;
+}
+
+.name, .type_name, .enum_name, .module_name {
+    margin-top: 12px;
+}
+
+
+.arguments, .returns {
+    text-transform: uppercase;
+}
+
+.module_name a, .type_name a, .enum_name a, .callbacks_title a, .module_navigation, .default, .subsection {
+    color: #777474;
+}
+
+a {
+    color: #2680C6; /* Blue */
+}
+.name a, .argument_name, .argument, .constant_name, .green {
+    color: #7CAF45; /* Green */
+}
+.return_name, .return {
+    color: #CC6600; /* Orange */
+    color: #D86C00; /* Orange */
+}
+.argument_name, .argument {
+    color: #E658A0; /* Pink */
+}
+
+.argument_name, .return_name {
+    width: 120px;
+}
+
+.argument_type, .return_type {
+    width: 100px;
+}
+
+.callbacks_title {
+    margin-top: 0;
+}
+
+.navigation_link a:hover, .function_link a:hover, .type_link a:hover, .enum_link a:hover, .return_type a:hover, .argument_type a:hover  {
+    background-color: #ECF3F7;
+}
+
+.background {
+    margin-left: -12px;
+    line-height: 150%;
+    background-color: #F5F5F5;
+    border-color: #D7D4D4;
+    background-color: #F7F4F4;
+    border-width: 1px;
+    border-style: solid;
+    padding: 2px 5px 2px 5px;
+    margin-left: -5px;
+}
+
+.function_section, .navigation_section, .module_section, .enum_section, .navigation_links_section {
+    margin-bottom: 40px;
+}
+
+.navigation_links_section {
+    margin-top: 20px;
+}
+
+.module_name, .callbacks_title {
+    font-size: 28px;
+}
+
+.light, .arguments, .returns, .subsection {
+    color: #A7A4A4;
+}


### PR DESCRIPTION
Changing CSS files can break old documentation files therefore we should keep the old css files with the old releases. We can then link to working documentations everytime even if there a changes to it.