### PR TITLE
Add transform and matrixlayout

### DIFF
--- a/modules/math/Math.lua
+++ b/modules/math/Math.lua
@@ -7,7 +7,8 @@ return {
     types = {
         require(path .. 'types.BezierCurve'),
         require(path .. 'types.CompressedData'),
-        require(path .. 'types.RandomGenerator')
+        require(path .. 'types.RandomGenerator'),
+        require(path .. 'types.Transform')
     },
     functions = {
         {
@@ -909,6 +910,7 @@ return {
         }
     },
     enums = {
-        require(path .. 'enums.CompressedDataFormat')
+        require(path .. 'enums.CompressedDataFormat'),
+        require(path .. 'enums.MatrixLayout')
     }
 }

--- a/modules/math/types/Transform.lua
+++ b/modules/math/types/Transform.lua
@@ -125,9 +125,11 @@ return {
 			variants = {
 				{
 					returns = {
-						type = 'Transform',
-						name = 'transform',
-						description = 'The Transform object the method was called on. Allows easily chaining Transform methods.'
+						{
+							type = 'Transform',
+							name = 'transform',
+							description = 'The Transform object the method was called on. Allows easily chaining Transform methods.'
+						}
 					}
 				}
 			}


### PR DESCRIPTION
2nd Attempt

Includes the following files...
```
modules/math/types/Transform.lua
modules/math/enums/MatrixLayout.lua
```
in `Math.lua`

`Transform.lua` was also modified as one of its return values was not wrapped in a table.

These were created from pull req #58

Hope this helps