### PR TITLE
Corrected HashFunction to EncodeFormat

### DIFF
--- a/modules/data/enums/EncodeFormat.lua
+++ b/modules/data/enums/EncodeFormat.lua
@@ -1,5 +1,5 @@
 return {
-    name = 'HashFunction',
+    name = 'EncodeFormat',
     description = 'Encoding format used to encode or decode data.',
     constants = {
         {


### PR DESCRIPTION
I noticed that the EncodeFormat.lua had `HashFunction` as its name instead of `EncodeFormat`