### PR TITLE
Remove deprecated & incorrect function variants

### DIFF
--- a/modules/graphics/Graphics.lua
+++ b/modules/graphics/Graphics.lua
@@ -1941,72 +1941,6 @@ return {
                         },
                     },
                 },
-                {
-                    description = 'Some Canvas formats have higher system requirements than the default format. Use love.graphics.getCanvasFormats to check for support.',
-                    arguments = {
-                        {
-                            type = 'number',
-                            name = 'width',
-                            description = 'The desired width of the Canvas.',
-                            default = 'window_width',
-                        },
-                        {
-                            type = 'number',
-                            name = 'height',
-                            description = 'The desired height of the Canvas.',
-                            default = 'window_height',
-                        },
-                        {
-                            type = 'CanvasFormat',
-                            name = 'format',
-                            description = 'The desired texture format of the Canvas.',
-                            default = '\'normal\'',
-                        },
-                    },
-                    returns = {
-                        {
-                            type = 'Canvas',
-                            name = 'canvas',
-                            description = 'A new Canvas with specified width and height.',
-                        },
-                    },
-                },
-                {
-                    description = 'Some Canvas formats have higher system requirements than the default format. Use love.graphics.getCanvasFormats to check for support.\n\nThe supported maximum number of MSAA samples varies depending on the system. Use love.graphics.getSystemLimits to check.\n\nIf the number of MSAA samples specified is greater than the maximum supported by the system, the Canvas will still be created but only using the maximum supported amount (this includes 0.)',
-                    arguments = {
-                        {
-                            type = 'number',
-                            name = 'width',
-                            description = 'The desired width of the Canvas.',
-                            default = 'window_width',
-                        },
-                        {
-                            type = 'number',
-                            name = 'height',
-                            description = 'The desired height of the Canvas.',
-                            default = 'window_height',
-                        },
-                        {
-                            type = 'CanvasFormat',
-                            name = 'format',
-                            description = 'The desired texture format of the Canvas.',
-                            default = '\'normal\'',
-                        },
-                        {
-                            type = 'number',
-                            name = 'msaa',
-                            description = 'The desired number of multisample antialiasing (MSAA) samples used when drawing to the Canvas.',
-                            default = '0',
-                        },
-                    },
-                    returns = {
-                        {
-                            type = 'Canvas',
-                            name = 'canvas',
-                            description = 'A new Canvas with specified width and height.',
-                        },
-                    },
-                },
             },
         },
         {
@@ -2282,27 +2216,6 @@ return {
                             type = 'Image',
                             name = 'image',
                             description = 'A new Image object which can be drawn on screen.',
-                        },
-                    },
-                },
-                {
-                    arguments = {
-                        {
-                            type = 'string',
-                            name = 'filename',
-                            description = 'The filepath to the image file (or a FileData or ImageData or CompressedImageData object.)',
-                        },
-                        {
-                            type = 'TextureFormat',
-                            name = 'format',
-                            description = 'The format to interpret the image\'s data as.',
-                        },
-                    },
-                    returns = {
-                        {
-                            type = 'Image',
-                            name = 'image',
-                            description = 'An Image object which can be drawn on screen.',
                         },
                     },
                 },

--- a/modules/graphics/Graphics.lua
+++ b/modules/graphics/Graphics.lua
@@ -2679,28 +2679,6 @@ return {
                         },
                     },
                 },
-                {
-                    description = 'Vertex shader code is run for every vertex drawn to the screen (for example, love.graphics.rectangle will produce 4 vertices) and is used to transform the vertex positions from their original coordinates into screen-space, as well as to send information such as per-vertex color and texture coordinate values to the pixel shader.\n\nPixel shader code is run for every pixel on the screen that a drawn object touches, and is used to produce the color that will be blended onto the screen at that pixel, often by reading from an image. Pixel shaders are sometimes called fragment shaders.\n\nThe varying keyword can be used to set a value in the vertex shader and have it interpolated in between vertices and passed down to the pixel shader.\n\nVertex and Pixel shader code can be combined into one file or string if you wrap the vertex-specific code in #ifdef VERTEX .. #endif and the pixel-specific code in #ifdef PIXEL .. #endif.\n\n== Built-in variables ==\n\nLÖVE provides several built-in variables for both pixel and vertex shaders. The full list can be found here: Shader Variables.',
-                    arguments = {
-                        {
-                            type = 'mat4',
-                            name = 'transform_projection',
-                            description = 'The transformation matrix affected by love.graphics.translate and friends combined with the orthographic projection matrix.',
-                        },
-                        {
-                            type = 'vec4',
-                            name = 'vertex_position',
-                            description = 'The raw un-transformed position of the current vertex.',
-                        },
-                    },
-                    returns = {
-                        {
-                            type = 'vec4',
-                            name = 'output_pos',
-                            description = 'The final transformed position of the current vertex.',
-                        },
-                    },
-                },
             },
         },
         {

--- a/modules/mouse/Mouse.lua
+++ b/modules/mouse/Mouse.lua
@@ -165,22 +165,6 @@ return {
                         },
                     },
                 },
-                {
-                    arguments = {
-                        {
-                            type = 'MouseConstant',
-                            name = 'buttonN',
-                            description = 'A button to check.',
-                        },
-                    },
-                    returns = {
-                        {
-                            type = 'boolean',
-                            name = 'anyDown',
-                            description = 'True if any specified button is down, false otherwise.',
-                        },
-                    },
-                },
             },
         },
         {


### PR DESCRIPTION
In `love.graphics`, variations using [`CanvasFormat`](https://love2d.org/wiki/CanvasFormat) and [`TextureFormat`](https://love2d.org/wiki/TextureFormat) have been deprecated. In `love.mouse`, [`MouseConstant`](https://love2d.org/wiki/MouseConstant) is no longer used.

Additionally, [`love.graphics.newShader`](https://love2d.org/wiki/love.graphics.newShader) had a variant that seems to have been erroneously pulled from the definition for the vertex shading function instead.

Fixes #92.