### PR TITLE
Replace "value" type with actual permitted types

### DIFF
--- a/modules/data/Data.lua
+++ b/modules/data/Data.lua
@@ -38,7 +38,7 @@ return {
                     },
                     returns = {
                         {
-                            type = 'value',
+                            type = 'CompressedData or string',
                             name = 'compressedData',
                             description = 'CompressedData/string which contains the compressed version of rawstring.',
                         },
@@ -70,7 +70,7 @@ return {
                     },
                     returns = {
                         {
-                            type = 'value',
+                            type = 'CompressedData or string',
                             name = 'compressedData',
                             description = 'CompressedData/string which contains the compressed version of data.',
                         },
@@ -102,7 +102,7 @@ return {
                     },
                     returns = {
                         {
-                            type = 'value',
+                            type = 'ByteData or string',
                             name = 'decoded',
                             description = 'ByteData/string which contains the decoded version of source.',
                         },
@@ -128,7 +128,7 @@ return {
                     },
                     returns = {
                         {
-                            type = 'value',
+                            type = 'ByteData or string',
                             name = 'decoded',
                             description = 'ByteData/string which contains the decoded version of source.',
                         },
@@ -155,7 +155,7 @@ return {
                     },
                     returns = {
                         {
-                            type = 'value',
+                            type = 'Data or string',
                             name = 'decompressedData',
                             description = 'Data/string containing the raw decompressed data.',
                         },
@@ -181,7 +181,7 @@ return {
                     },
                     returns = {
                         {
-                            type = 'value',
+                            type = 'Data or string',
                             name = 'decompressedData',
                             description = 'Data/string containing the raw decompressed data.',
                         },
@@ -207,7 +207,7 @@ return {
                     },
                     returns = {
                         {
-                            type = 'value',
+                            type = 'Data or string',
                             name = 'decompressedData',
                             description = 'Data/string containing the raw decompressed data.',
                         },
@@ -245,7 +245,7 @@ return {
                     },
                     returns = {
                         {
-                            type = 'value',
+                            type = 'ByteData or string',
                             name = 'encoded',
                             description = 'ByteData/string which contains the encoded version of source.',
                         },
@@ -277,7 +277,7 @@ return {
                     },
                     returns = {
                         {
-                            type = 'value',
+                            type = 'ByteData or string',
                             name = 'encoded',
                             description = 'ByteData/string which contains the encoded version of source.',
                         },
@@ -477,19 +477,19 @@ return {
                             description = 'A string determining how the values are packed. Follows the rules of Lua 5.3\'s string.pack format strings.',
                         },
                         {
-                            type = 'value',
+                            type = 'number or boolean or string',
                             name = 'v1',
                             description = 'The first value (number, boolean, or string) to serialize.',
                         },
                         {
-                            type = 'value',
+                            type = 'number or boolean or string',
                             name = '...',
                             description = 'Additional values to serialize.',
                         },
                     },
                     returns = {
                         {
-                            type = 'value',
+                            type = 'Data or string',
                             name = 'data',
                             description = 'Data/string which contains the serialized data.',
                         },
@@ -522,12 +522,12 @@ return {
                     },
                     returns = {
                         {
-                            type = 'value',
+                            type = 'number or boolean or string',
                             name = 'v1',
                             description = 'The first value (number, boolean, or string) that was unpacked.',
                         },
                         {
-                            type = 'value',
+                            type = 'number or boolean or string',
                             name = '...',
                             description = 'Additional unpacked values.',
                         },
@@ -560,12 +560,12 @@ return {
                     },
                     returns = {
                         {
-                            type = 'value',
+                            type = 'number or boolean or string',
                             name = 'v1',
                             description = 'The first value (number, boolean, or string) that was unpacked.',
                         },
                         {
-                            type = 'value',
+                            type = 'number or boolean or string',
                             name = '...',
                             description = 'Additional unpacked values.',
                         },

--- a/modules/filesystem/Filesystem.lua
+++ b/modules/filesystem/Filesystem.lua
@@ -782,7 +782,7 @@ return {
                     },
                     returns = {
                         {
-                            type = 'value',
+                            type = 'FileData or string',
                             name = 'contents',
                             description = 'FileData or string containing the file contents.',
                         },

--- a/modules/filesystem/types/File.lua
+++ b/modules/filesystem/types/File.lua
@@ -226,7 +226,7 @@ return {
                     },
                     returns = {
                         {
-                            type = 'value',
+                            type = 'FileData or string',
                             name = 'contents',
                             description = 'FileData or string containing the read bytes.',
                         },


### PR DESCRIPTION
In all cases, the type "value" was described in more precise terms in the entry's description. This PR simply copies the definition from the description over into the type.

Precedent for the used notation ("x or y") exists in [`Rasterizer:hasGlyphs`](https://love2d.org/wiki/Rasterizer:hasGlyphs) and [`love.graphics.newImage`](https://love2d.org/wiki/love.graphics.newImage).