### PR TITLE
Compatible with Lua 5.4

### DIFF
--- a/love_api.lua
+++ b/love_api.lua
@@ -1308,5 +1308,6 @@ return {
         require(path .. 'modules.touch.Touch'),
         require(path .. 'modules.video.Video'),
         require(path .. 'modules.window.Window'),
+        nil,
     },
 }


### PR DESCRIPTION
In Lua 5.4, `require` will return more than one return value, causing unexpected values to be inserted into the array.

![love 5 4](https://user-images.githubusercontent.com/5213431/126284443-00563f81-0601-405d-a130-941c83b4e1c6.png)
