### PR TITLE
Update Decoder.lua

### DIFF
--- a/modules/sound/types/Decoder.lua
+++ b/modules/sound/types/Decoder.lua
@@ -26,6 +26,17 @@ return {
             },
         },
         {
+            name = 'decode',
+            description = 'Decodes the audio and returns a SoundData object containing the decoded audio data.',
+            variants = {
+                returns = {
+                    type = 'SoundData',
+                    name = 'soundData',
+                    description = 'Decoded audio data.'
+                }
+            }
+        },
+        {
             name = 'getBitDepth',
             description = 'Returns the number of bits per sample.',
             variants = {


### PR DESCRIPTION
This pull request adds the missing `Decoder:decode()` method to the documentation.