### PR TITLE
update VideoStream.lua

### DIFF
--- a/modules/video/types/VideoStream.lua
+++ b/modules/video/types/VideoStream.lua
@@ -10,5 +10,89 @@ return {
         'Object',
     },
     functions = {
+        {
+            name = 'getFilename',
+            description = 'Gets the filename of the VideoStream.',
+            variants = {
+                {
+                    returns = {
+                        {
+                            type = 'string',
+                            name = 'filename',
+                            description = 'The filename of the VideoStream'
+                        },
+                    },
+                },
+            },
+        },
+        {
+            name = 'isPlaying',
+            description = 'Gets whether the VideoStream is playing.',
+            variants = {
+                {
+                    returns = {
+                        {
+                            type = 'boolean',
+                            name = 'playing',
+                            description = 'Whether the VideoStream is playing.'
+                        },
+                    },
+                },
+            },
+        },
+        {
+            name = 'pause',
+            description = 'Pauses the VideoStream.',
+            variants = {
+                {
+                },
+            },
+        },
+        {
+            name = 'play',
+            description = 'Plays the VideoStream.',
+            variants = {
+                {
+                },
+            },
+        },
+        {
+            name = 'rewind',
+            description = 'Rewinds the VideoStream. Synonym to VideoStream:seek(0).',
+            variants = {
+                {
+                },
+            },
+        },
+        {
+            name = 'seek',
+            description = 'Sets the current playback position of the VideoStream.',
+            variants = {
+                {
+                    arguments = {
+                        {
+                            type = 'number',
+                            name = 'offset',
+                            description = 'The time in seconds since the beginning of the VideoStream.'
+                        },
+                    },
+                },
+            },
+        },
+        {
+            name = 'tell',
+            description = 'Gets the current playback position of the VideoStream.',
+            variants = {
+                {
+                    returns = {
+                        {
+                            type = 'number',
+                            name = 'seconds',
+                            description = 'The number of seconds sionce the beginning of the VideoStream.'
+                        },
+                    },
+                },
+            },
+        },
     },
 }


### PR DESCRIPTION
**Summary**
This pull request updates VideoStream.lua to add the remaining functions. However, the only one undocumented is `VideoStream:setSync` (which has yet to be added to the LÖVE Wiki).

**Additional Details**
I know I said that the physics stuff was probably the last thing this needed, but after cleaning up the python script I'm using to compare the API in LÖVE Potion with LÖVE via this Wiki, I found that the VideoStream stuff was not documented.