### PR TITLE
Add return to love.errorhandler

### DIFF
--- a/love_api.lua
+++ b/love_api.lua
@@ -472,6 +472,13 @@ return {
                             description = 'The error message.',
                         },
                     },
+                    returns = {
+                        {
+                            type = 'function',
+                            name = 'mainLoop',
+                            description = 'Function which handles one frame, including events and rendering, when called. If this is nil then LÖVE exits immediately.',
+                        },
+                    },
                 },
             },
         },


### PR DESCRIPTION
This pull request fixes an issue in which the `love.errorhandler` callback did not have a documented return value, despite returning the main loop function, as documented on the [LOVE wiki](https://love2d.org/wiki/love.errorhandler).