### PR TITLE
Fix Transform:setMatrix arguments

### DIFF
--- a/modules/math/types/Transform.lua
+++ b/modules/math/types/Transform.lua
@@ -222,8 +222,68 @@ return {
                         },
                         {
                             type = 'number',
-                            name = '...',
-                            description = 'Additional matrix elements.',
+                            name = 'e1_3',
+                            description = 'The third column of the first row of the matrix.',
+                        },
+                        {
+                            type = 'number',
+                            name = 'e1_4',
+                            description = 'The fourth column of the first row of the matrix.',
+                        },
+                        {
+                            type = 'number',
+                            name = 'e2_1',
+                            description = 'The first column of the second row of the matrix.',
+                        },
+                        {
+                            type = 'number',
+                            name = 'e2_2',
+                            description = 'The second column of the second row of the matrix.',
+                        },
+                        {
+                            type = 'number',
+                            name = 'e2_3',
+                            description = 'The third column of the second row of the matrix.',
+                        },
+                        {
+                            type = 'number',
+                            name = 'e2_4',
+                            description = 'The fourth column of the second row of the matrix.',
+                        },
+                        {
+                            type = 'number',
+                            name = 'e3_1',
+                            description = 'The first column of the third row of the matrix.',
+                        },
+                        {
+                            type = 'number',
+                            name = 'e3_2',
+                            description = 'The second column of the third row of the matrix.',
+                        },
+                        {
+                            type = 'number',
+                            name = 'e3_3',
+                            description = 'The third column of the third row of the matrix.',
+                        },
+                        {
+                            type = 'number',
+                            name = 'e3_4',
+                            description = 'The fourth column of the third row of the matrix.',
+                        },
+                        {
+                            type = 'number',
+                            name = 'e4_1',
+                            description = 'The first column of the fourth row of the matrix.',
+                        },
+                        {
+                            type = 'number',
+                            name = 'e4_2',
+                            description = 'The second column of the fourth row of the matrix.',
+                        },
+                        {
+                            type = 'number',
+                            name = 'e4_3',
+                            description = 'The third column of the fourth row of the matrix.',
                         },
                         {
                             type = 'number',


### PR DESCRIPTION
The original wiki entry had a ... in the middle, and the API was copied straight from it. This confused type annotators and made them think it was a vararg in the middle.