### PR TITLE
added missing Mesh:setVertices optional argument

### DIFF
--- a/modules/graphics/types/Mesh.lua
+++ b/modules/graphics/types/Mesh.lua
@@ -735,6 +735,12 @@ return {
                             description = 'The index of the first vertex to replace.',
                             default = '1',
                         },
+                        {
+                            type = 'number',
+                            name = 'count',
+                            description = 'Amount of vertices to replace.',
+                            default = 'all',
+                        }
                     },
                 },
                 {


### PR DESCRIPTION
I was using the very nice [Lua language server extension](https://github.com/LuaLS/lua-language-server) which supports some 3rd party libraries like Love2D automatically; it generates its meta files directly from this repo. I noticed the API doesn't have any info about the optional `count` argument added to `Mesh:setVertices` in 11.3. You can see it in the Wiki here: https://love2d.org/wiki/Mesh:setVertices

Hopefully I did it right and maybe it will help people out!