### PR TITLE
Add defaults to setFilter and setDefaultFilter

### DIFF
--- a/modules/graphics/Graphics.lua
+++ b/modules/graphics/Graphics.lua
@@ -4510,6 +4510,7 @@ return {
                             type = 'FilterMode',
                             name = 'mag',
                             description = 'Filter mode used when scaling the image up.',
+                            default = 'min',
                         },
                         {
                             type = 'number',

--- a/modules/graphics/types/Texture.lua
+++ b/modules/graphics/types/Texture.lua
@@ -329,6 +329,7 @@ return {
                             type = 'FilterMode',
                             name = 'mag',
                             description = 'Filter mode to use when magnifying the texture (rendering it at a larger size on-screen than its size in pixels).',
+                            default = 'min',
                         },
                         {
                             type = 'number',


### PR DESCRIPTION
The current definition treats `mag` as a required parameter in both `love.graphics.setDefaultFilter` and `Texture:setFilter`, but the wiki shows both as defaulting to `min`. This pull request would change it to match.

https://love2d.org/wiki/love.graphics.setDefaultFilter
https://love2d.org/wiki/Texture:setFilter

Sorry if this was an intentional decision, but I figured it was worth a pull request after seeing other functions default to parameter names.