### PR TITLE
Add defaults to Quad:setViewport

### DIFF
--- a/modules/graphics/types/Quad.lua
+++ b/modules/graphics/types/Quad.lua
@@ -89,12 +89,16 @@ return {
                         {
                             type = 'number',
                             name = 'sw',
-                            description = 'The reference width, the width of the Image. (Must be greater than 0.)',
+                            description =
+                            'Optional new reference width, the width of the Texture. Must be greater than 0 if set.',
+                            default = 'nil'
                         },
                         {
                             type = 'number',
                             name = 'sh',
-                            description = 'The reference height, the height of the Image. (Must be greater than 0.)',
+                            description =
+                            'Optional new reference height, the height of the Texture. Must be greater than 0 if set.',
+                            default = 'nil'
                         },
                     },
                 },


### PR DESCRIPTION
Per [the wiki](https://love2d.org/wiki/Quad:setViewport), sw and sh should default to 'nil'.