### PR TITLE
Fix love.graphics.newImageFont variants

### DIFF
--- a/modules/graphics/Graphics.lua
+++ b/modules/graphics/Graphics.lua
@@ -2365,6 +2365,12 @@ return {
                             name = 'glyphs',
                             description = 'A string of the characters in the image in order from left to right.',
                         },
+                        {
+                            type = 'number',
+                            name = 'extraspacing',
+                            description = 'Additional spacing (positive or negative) to apply to each glyph in the Font.',
+                            default = '0',
+                        },
                     },
                     returns = {
                         {
@@ -2386,32 +2392,11 @@ return {
                             name = 'glyphs',
                             description = 'A string of the characters in the image in order from left to right.',
                         },
-                    },
-                    returns = {
-                        {
-                            type = 'Font',
-                            name = 'font',
-                            description = 'A Font object which can be used to draw text on screen.',
-                        },
-                    },
-                },
-                {
-                    description = 'Instead of using this function, consider using a BMFont generator such as bmfont, littera, or bmGlyph with love.graphics.newFont. Because slime said it was better.',
-                    arguments = {
-                        {
-                            type = 'string',
-                            name = 'filename',
-                            description = 'The filepath to the image file.',
-                        },
-                        {
-                            type = 'string',
-                            name = 'glyphs',
-                            description = 'A string of the characters in the image in order from left to right.',
-                        },
                         {
                             type = 'number',
                             name = 'extraspacing',
                             description = 'Additional spacing (positive or negative) to apply to each glyph in the Font.',
+                            default = '0',
                         },
                     },
                     returns = {


### PR DESCRIPTION
`extraspacing` is documented on the [love2d wiki](https://love2d.org/wiki/love.graphics.newImageFont) as an optional argument in both variants of newImageFont, however it was in the API only in a third variant matching the filename argument.

This also removes the description of the third variant, as it is a Note on the page and not a function description.

<img width="523" height="789" alt="image" src="https://github.com/user-attachments/assets/403f4a2d-3c8c-41d4-9409-13f56bc003ad" />
