### PR TITLE
Fix love.keyboard.isDown to accept table as parameter

### DIFF
--- a/modules/keyboard/Keyboard.lua
+++ b/modules/keyboard/Keyboard.lua
@@ -136,6 +136,22 @@ return {
                         },
                     },
                 },
+                {
+                    arguments = {
+                        {
+                            type = 'table<number,KeyConstant>',
+                            name = 'keys',
+                            description = 'A table containing keys to check.',
+                        },
+                    },
+                    returns = {
+                        {
+                            type = 'boolean',
+                            name = 'anyDown',
+                            description = 'True if any of the keys in the table are down, false if not.',
+                        },
+                    },
+                },
             },
         },
         {


### PR DESCRIPTION
As stated in the [official wiki](https://love2d.org/wiki/love.keyboard.isDown), starting from version 0.10.2 `love.keyboard.isDown` also accepts a table as a parameter. My fix adds this variant to the API.

<img width="400" alt="updated" src="https://github.com/user-attachments/assets/aa8fa277-829a-486c-a618-fe914149694d" />
