### PR TITLE
Fix: update vsync type to number with new description

### DIFF
--- a/modules/window/Window.lua
+++ b/modules/window/Window.lua
@@ -689,10 +689,10 @@ return {
                                     default = '\'desktop\'',
                                 },
                                 {
-                                    type = 'boolean',
+                                    type = 'number',
                                     name = 'vsync',
-                                    description = 'True if LÖVE should wait for vsync, false otherwise.',
-                                    default = 'true',
+                                    description = 'Enables or disables vertical synchronisation (\'vsync\'): 1 to enable vsync, 0 to disable it, and -1 to use adaptive vsync (where supported). Prior to 11.0 this was a boolean flag, rather than a number.',
+                                    default = '1',
                                 },
                                 {
                                     type = 'number',


### PR DESCRIPTION
Changed vsync type from boolean to number and updated its description and default value.

https://love2d.org/wiki/love.window.setMode